### PR TITLE
Fixing the command to publish challenge_started message

### DIFF
--- a/startup/challenge/session.yml
+++ b/startup/challenge/session.yml
@@ -40,7 +40,7 @@ windows:
           rosrun ardupilot_gazebo automatic_takeoff.sh 2 /$UAV_NAMESPACE/odometry
           sleep 20
           rosservice call /$UAV_NAMESPACE/spawn_ball
-          rostopic pub --latch std_msgs/Bool /$UAV_NAMESPACE/challenge_started True
+          rostopic pub --latch /$UAV_NAMESPACE/challenge_started std_msgs/Bool True
   - trajectory:
       layout: tiled
       panes:


### PR DESCRIPTION
The arguments for `rostopic pub` command are out of order, resulting in the error
`ERROR: invalid topic type: /red/challenge_started`

Simply swapping the positions to fix the command